### PR TITLE
Update qa_model.py

### DIFF
--- a/qa_models/qa_model.py
+++ b/qa_models/qa_model.py
@@ -9,7 +9,7 @@ from torch.optim.adamw import AdamW
 import logging
 
 from pytorch_lightning.utilities import rank_zero_only
-from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.loggers.logger import Logger
 
 from qa_models.qa_utils import find_offset_index, get_token_offsets, \
     find_text_start_end_indices
@@ -369,5 +369,5 @@ class SimpleTextLogger:
         self.logger.info(data)
 
     @classmethod
-    def from_logger(cls, logger: LightningLoggerBase):
+    def from_logger(cls, logger: Logger):
         return cls(logger.log_dir)


### PR DESCRIPTION
Due to changes described on "[1.7.0] - Deprecated" section: https://pytorch-lightning.readthedocs.io/en/stable/generated/CHANGELOG.html#id42 (PyTorch-Lightning's CHANGELOG)